### PR TITLE
fix: enable emoji icons on Windows terminals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ Thumbs.db
 *.env
 *.secret
 settings.local.json
+
+# Temp
+.superpowers/
+__pycache__/
+*.pyc

--- a/hooks/statusline.sh
+++ b/hooks/statusline.sh
@@ -37,11 +37,20 @@ if git -C "$cwd" rev-parse --is-inside-work-tree --no-optional-locks 2>/dev/null
 fi
 
 # --- Icon detection ---
-_use_emoji=true
-case "${LANG:-}${LC_ALL:-}${LC_CTYPE:-}" in
-    *[Uu][Tt][Ff]-8*|*[Uu][Tt][Ff]8*) ;;
-    *) _use_emoji=false ;;
-esac
+_use_emoji=false
+# Non-Windows: check UTF-8 locale
+if [ -z "${USERPROFILE:-}" ]; then
+    case "${LANG:-}${LC_ALL:-}${LC_CTYPE:-}" in
+        *[Uu][Tt][Ff]-8*|*[Uu][Tt][Ff]8*) _use_emoji=true ;;
+    esac
+else
+    # Windows: only enable emoji for terminals known to support Unicode
+    # WT_SESSION = Windows Terminal, TERM_PROGRAM = VS Code / mintty
+    if [ -n "${WT_SESSION:-}" ] || [ -n "${TERM_PROGRAM:-}" ]; then
+        _use_emoji=true
+    fi
+fi
+# Always disable for known dumb terminals
 case "${TERM:-dumb}" in
     dumb|linux|vt100|vt220) _use_emoji=false ;;
 esac

--- a/hooks/statusline.sh
+++ b/hooks/statusline.sh
@@ -45,10 +45,15 @@ if [ -z "${USERPROFILE:-}" ]; then
     esac
 else
     # Windows: only enable emoji for terminals known to support Unicode
-    # WT_SESSION = Windows Terminal, TERM_PROGRAM = VS Code / mintty
-    if [ -n "${WT_SESSION:-}" ] || [ -n "${TERM_PROGRAM:-}" ]; then
+    # WT_SESSION  = Windows Terminal
+    # MSYSTEM     = Git Bash / mintty (MINGW64, MINGW32, MSYS, etc.)
+    # TERM_PROGRAM whitelist: vscode (VS Code integrated terminal)
+    if [ -n "${WT_SESSION:-}" ] || [ -n "${MSYSTEM:-}" ]; then
         _use_emoji=true
     fi
+    case "${TERM_PROGRAM:-}" in
+        vscode) _use_emoji=true ;;
+    esac
 fi
 # Always disable for known dumb terminals
 case "${TERM:-dumb}" in


### PR DESCRIPTION
## Summary
- Fix statusline icons not showing on Windows PowerShell/Git Bash
- `LANG`/`LC_ALL`/`LC_CTYPE` are empty in Windows Git Bash, causing emoji detection to fail
- Now detects Windows via `USERPROFILE` and only enables emoji for terminals known to support Unicode (`WT_SESSION` for Windows Terminal, `TERM_PROGRAM` for VS Code/mintty)
- Traditional terminals (cmd.exe, conhost) continue to use text fallbacks (`M:`, `D:`, `br:`)

## Test plan
- [ ] Verify icons display in Windows Terminal (PowerShell)
- [ ] Verify icons display in VS Code integrated terminal
- [ ] Verify text fallback in cmd.exe
- [ ] Verify no regression on macOS/Linux (UTF-8 locale check unchanged)