### PR TITLE
docs: list Agent QA MCP server

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,6 +8,10 @@
 |--------|-----------|---------|
 | **[Lark-MCP](https://github.com/larksuite/lark-openapi-mcp)** | stdio | Official Feishu/Lark OpenAPI — call Lark platform APIs from AI assistants |
 
+## Related QA Servers
+
+- **[Agent QA](https://github.com/vostride/agent-qa)** — The self-improving QA agent for software teams. Run natural-language web and mobile tests through its MCP server, CLI, or portable agent skills. Requires Node.js 24+ and a configured Agent QA workspace; start the server with `npx --yes agent-qa mcp`.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary

Adds [Agent QA](https://github.com/vostride/agent-qa) to `mcp/README.md` as a related, optional QA MCP server.

Agent QA is the self-improving QA agent for software teams. It supports natural-language web and mobile tests through MCP, CLI, and portable agent skills. The entry includes its exact package launch command (`npx --yes agent-qa mcp`), Node.js 24+ requirement, and configured-workspace prerequisite.

This is documentation-only: Agent QA is not added to the starter's installed/default MCP set, so the existing menu counts, installer behavior, and Lark configuration remain unchanged.

## Checks

- Verified the documented command against Agent QA's current CLI package.
- `git diff --check` passes.

Disclosure: I am affiliated with Agent QA and Vostride.