### PR TITLE
Add awesome-claude-code-hooks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Smart merge on re-install preserves your overrides for `env`, `permissions.allow
 - [Anthropic Engineering](https://www.anthropic.com/engineering) / [OpenAI Engineering](https://openai.com/news/engineering/)
 - [Claude Code Best Practice](https://github.com/shanraisshan/claude-code-best-practice) by shanraisshan
 - [Claude How To](https://github.com/luongnv89/claude-howto) by luongnv89
+- [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) by loqimean — curated list of Claude Code hooks
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,6 +197,7 @@ irm https://raw.githubusercontent.com/Mizoreww/awesome-claude-code-config/main/i
 - [Anthropic Engineering](https://www.anthropic.com/engineering) / [OpenAI Engineering](https://openai.com/news/engineering/)
 - [Claude Code Best Practice](https://github.com/shanraisshan/claude-code-best-practice) by shanraisshan
 - [Claude How To](https://github.com/luongnv89/claude-howto) by luongnv89
+- [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) by loqimean — Claude Code hooks 精选列表
 
 ## License
 


### PR DESCRIPTION
Adds a link to loqimean/awesome-claude-code-hooks in the Acknowledgements section of README.md and README.zh-CN.md. It's a curated list of Claude Code hooks, similar in spirit to the other resource links already in that section.

No other changes.